### PR TITLE
Remove outdated .app setup steps

### DIFF
--- a/Distribution/MacOSX/Internal.hs
+++ b/Distribution/MacOSX/Internal.hs
@@ -56,32 +56,5 @@ osxIncantations ::
   FilePath -- ^ Path to application bundle root.
   -> MacApp -> IO ()
 osxIncantations appPath app =
-  do dtools <- developerTools
-     runCommand $ dtools </> "Rez Carbon.r -o " ++ appPath </> pathInApp app (appName app)
-     writeFile (appPath </> "PkgInfo") "APPL????"
-     runCommand $ dtools </> "SetFile -a C " ++ appPath </> "Contents" -- Tell Finder about the icon.
+  do writeFile (appPath </> "PkgInfo") "APPL????"
      return ()
-
-runCommand :: String -> IO ()
-runCommand commandExec =
-  do putStrLn $ "Running: " ++ commandExec
-     exitValue <- system commandExec
-     case exitValue of
-        ExitSuccess -> return ()
-        _ -> do putStrLn $ "Warning - Could not run the command \""
-                           ++ commandExec ++ "\". Please check your local `XCode` configuration."
-                exitFailure
-
--- | Path to the developer tools directory, if one exists
-developerTools :: IO FilePath
-developerTools =
-   do ds <- filterM doesDirectoryExist cands
-      case ds of
-        [] -> do putStrLn $ "Can't find the developer tools directory. Have you installed the Developer tools?\n"
-                            ++ "I tried looking for:\n" ++ unlines (map ("* " ++) cands)
-                 exitWith (ExitFailure 1)
-        (d:_) -> return d
-  where
-    cands = [ "/Applications/XCode.app/Contents/Developer/Tools"
-            , "/Developer/Tools"
-            ]

--- a/README.md
+++ b/README.md
@@ -25,42 +25,6 @@ and produces an application bundle in the current working directory.
 
 ## Troubleshooting
 
-### ~ Rez is exiting with error
-
-`cabal-macosx` uses Xcode's Carbon Tools to prepare an app bundle.
-
-In order to run successfully the process, please be sure that Xcode is installed properly on your machine.
-
-Also, note that `cabal-macosx` runs the Carbon tool `Rez` in this way:
-
-```
-/path/to/tools/Rez Carbon.r -o dist/build/SomeProject.app/Contents/MacOS/SomeProject
-```
-
-So after the Xcode's installation, please run from command line:
-
-```
-xcode-select --install
-```
-
-to prevent the necessity of specifying the include paths like this:
-
-```
-/path/to/tools/Rez -F /developer/path/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/ Carbon.r -o dist/build/SomeProject.app/Contents/MacOS/SomeProject
-```
-
-for the Carbon tools. `cabal-macosx` assumes that the paths are properly configured otherwise it will stop the building process and returning an error similar to:
-
-```
-failed to find Carbon/Carbon.r
-### /Applications/XCode.app/Contents/Developer/Tools/Rez - SysError 0 during open of "Carbon.r".
-Fatal Error!
-### /Applications/XCode.app/Contents/Developer/Tools/Rez - Fatal Error, can't recover.
-Carbon.r: ### /Applications/XCode.app/Contents/Developer/Tools/Rez - Since errors occurred, dist/build/NetMonitor.app/Contents/MacOS/NetMonitor's resource fork was not written.
-```
-
-(and eventually deleting the built local binary too).
-
 ### ~ Install fails inside a sandbox
 
 If you get an error similar to this:

--- a/tests/Distribution/MacOSX/Internal/Tests.hs
+++ b/tests/Distribution/MacOSX/Internal/Tests.hs
@@ -1,21 +1,18 @@
 module Distribution.MacOSX.Internal.Tests where
 
-import System.IO.Temp (withSystemTempDirectory)
-import Control.Exception (SomeException, catch)
 import Prelude hiding (catch)
 import Test.HUnit (Assertion, assertEqual)
 import Test.Framework (Test, mutuallyExclusive, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 import Distribution.PackageDescription (BuildInfo(..), Executable(..), emptyBuildInfo)
 
-import Distribution.MacOSX.Internal (osxIncantations, getMacAppsForBuildableExecutors)
+import Distribution.MacOSX.Internal (getMacAppsForBuildableExecutors)
 import Distribution.MacOSX.Common
 
 macosxInternalTests :: Test
 macosxInternalTests = testGroup "Distribution.MacOSX.Internal"
     [ mutuallyExclusive $ testGroup "MacOSX Internal"
-        [ testCase "should exit with an exit-failure as Xcode's Carbon Tools fail to run" testCarbonTools,
-          -- I should consider to use QuickCheck maybe... :)
+        [ -- I should consider to use QuickCheck maybe... :)
           testCase "given nothing then should not try to build any mac-app" testBuildMacApp_noInput,
           testCase "given no executables then should not try to build any mac-app" testBuildMacApp_noExecutables,
           testCase "given only two executables then should try to build two mac-apps" testBuildMacApp_twoBuildableExecutables,
@@ -23,15 +20,6 @@ macosxInternalTests = testGroup "Distribution.MacOSX.Internal"
           testCase "given two executables and one not executable and two apps then should try to build one mac-app" testBuildMacApp_twoAppsAndTwoExecutablesOneBuildableOneNot
         ]
     ]
-
-testCarbonTools :: Assertion
-testCarbonTools = do
-    let macApp = MacApp "DummyApp" Nothing Nothing [] [] DoNotChase
-
-    withSystemTempDirectory "DummyAppPath" $ \tmpDir
-        -> osxIncantations tmpDir macApp -- some problems here to add `assertFailure` after
-             `catch`
-                 (\e -> putStrLn $ "Catched: " ++ show (e :: SomeException))
 
 testBuildMacApp_noInput :: Assertion
 testBuildMacApp_noInput = do


### PR DESCRIPTION
- Rez is a tool from Carbon (and previously OS 9) that builds and adds resource fork data. Carbon was deprecated in 2012, and Cocoa does not use resource fork data in executables. Further, Xcode's default Mac app template does not use Rez, nor do any system apps include resource forks in their executables since at least 10.10 (and probably earlier).

- SetFile is not needed for the OS to find the app's icon since at least 10.10 (and probably earlier).

Fixes #2.

This is part of the work from @biglambda's [bounty for command line creation of Haskell OS X app bundles](https://www.reddit.com/r/haskell/comments/5s96gd/im_creating_a_bounty_for_anyone_who_can_modernize/).