### PR TITLE
Ensure libraries are writable during install name updates

### DIFF
--- a/Distribution/MacOSX/Dependencies.hs
+++ b/Distribution/MacOSX/Dependencies.hs
@@ -213,10 +213,15 @@ updateDependency ::
 updateDependency appPath app src tgt =
   do putStrLn $ "Updating " ++ newLib ++ "'s dependency on " ++ tgt ++
                    " to " ++ tgt'
+     -- Ensure we have write permissions while editing the library. Notably,
+     -- Homebrew removes write permissions from installed files.
+     perm <- getPermissions newLib
+     setPermissions newLib perm { writable = True }
      let cmd = iTool ++ " -change " ++ show tgt ++ " " ++ show tgt' ++
                    " " ++ show newLib
      --putStrLn cmd
      ExitSuccess <- system cmd
+     setPermissions newLib perm
      return ()
   where tgt' = "@executable_path/../Frameworks/" </> makeRelative "/" tgt
         newLib = appPath </> pathInApp app src

--- a/Distribution/MacOSX/Dependencies.hs
+++ b/Distribution/MacOSX/Dependencies.hs
@@ -219,9 +219,11 @@ updateDependency appPath app src tgt =
      setPermissions newLib perm { writable = True }
      let cmd = iTool ++ " -change " ++ show tgt ++ " " ++ show tgt' ++
                    " " ++ show newLib
-     --putStrLn cmd
-     ExitSuccess <- system cmd
+     exitCode <- system cmd
      setPermissions newLib perm
+     when (exitCode /= ExitSuccess) $
+       error $ "Failed to update library dependencies on " ++ show newLib ++
+        " with command: " ++ cmd
      return ()
   where tgt' = "@executable_path/../Frameworks/" </> makeRelative "/" tgt
         newLib = appPath </> pathInApp app src


### PR DESCRIPTION
The use case for this is linking to libraries from Homebrew, which have their write bits removed. This also adds an error message for when `install_name_tool` fails.

This is part of the work from @biglambda's [bounty for command line creation of Haskell OS X app bundles](https://www.reddit.com/r/haskell/comments/5s96gd/im_creating_a_bounty_for_anyone_who_can_modernize/).