### PR TITLE
Ignores contents that start with @

### DIFF
--- a/Distribution/MacOSX/Dependencies.hs
+++ b/Distribution/MacOSX/Dependencies.hs
@@ -91,7 +91,8 @@ appDependencyGraph appPath app =
     ChaseWithDefaults -> appDependencyGraph appPath app {
                            appDeps = ChaseWith defaultExclusions
                          }
-    ChaseWith xs -> do putStrLn "Building dependency graph"
+    ChaseWith xs -> do putStrLn "Building dependency graph*"
+                       putStrLn $ "Roots" ++ show roots
                        buildDependencyGraph appPath app dgInitial roots [] xs
     DoNotChase -> return dgInitial
   where roots = appName app : otherBins app
@@ -142,7 +143,11 @@ getFDeps ::
   -> Exclusions -- ^ List of exclusions for dependency chasing.
   -> IO FDeps
 getFDeps appPath app path exclusions =
-  do contents <- readProcess oTool ["-L", absPath] ""
+  do putStrLn $ "path: " ++ path
+     --testing  <- readProcess oTool ["-l", absPath] ""
+     --putStrLn $ "testing: " ++ testing
+     contents <- readProcess oTool ["-L", absPath] ""
+     putStrLn $ "contents: " ++ contents
      case parse parseFileDeps "" contents of
        Left err -> error $ show err
        Right fDeps -> return $ exclude exclusions fDeps
@@ -152,6 +157,7 @@ getFDeps appPath app path exclusions =
         parseFileDeps :: Parser FDeps
         parseFileDeps = do f <- manyTill (noneOf ":") (char ':')
                            _ <- char '\n'
+
                            deps <- parseDepOrName `sepEndBy` char '\n'
                            eof
                            return $ FDeps f $ filter (f /=) $ catMaybes deps
@@ -159,12 +165,22 @@ getFDeps appPath app path exclusions =
         parseDepOrName = do c <- oneOf "\t/"
                             case c of
                               '\t' -> -- A dependency.
-                                      do dep <- parseDep
-                                         return $ Just dep
+                                      do dep <- parseDepOrIgnoreAt
+                                         return $ dep
                               '/' -> -- Same filename, alternative arch
                                      do _ <- manyTill (noneOf ":") (char ':')
                                         return Nothing
                               _ -> error "Can't happen"
+        parseDepOrIgnoreAt :: Parser (Maybe FilePath)
+        parseDepOrIgnoreAt = do c <- lookAhead (oneOf "/@")
+                                case c of
+                                  '/' -> -- A dependency.
+                                         do dep <- parseDep
+                                            return $ Just $ dep
+                                  '@' -> -- ignore entries that start with @
+                                         do _ <- manyTill (noneOf ")") (char ')')
+                                            return Nothing
+                                  _ -> error "Can't happen"
         parseDep :: Parser FilePath
         parseDep = do dep <- manyTill (noneOf " ") (char ' ')
                       _ <- char '('


### PR DESCRIPTION
I was trying to use SFML bindings and I found that otool would return some paths that begin with @rpath so I modified the parser to ignore these.