### PR TITLE
WIP: Convert from "UnqualComponentName" to "String"

### DIFF
--- a/Distribution/MacOSX/Internal.hs
+++ b/Distribution/MacOSX/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 {- | Cabal support for creating Mac OSX application bundles.
 
 GUI applications on Mac OSX should be run as application /bundles/;
@@ -25,7 +26,9 @@ import System.Cmd ( system )
 import System.Exit
 import System.FilePath
 import Control.Monad (filterM)
+import Data.String (fromString)
 import System.Directory (doesDirectoryExist)
+import Distribution.Text (display)
 import Distribution.PackageDescription (BuildInfo(..), Executable(..))
 
 import Distribution.MacOSX.Common
@@ -40,11 +43,15 @@ getMacAppsForBuildableExecutors macApps executables =
     [] -> map mkDefault buildables
     xs -> filter buildableApp xs
   where -- Make a default MacApp in absence of explicit from Setup.hs
+#if MIN_VERSION_Cabal(2,0,0)
+        mkDefault x = MacApp (display $ exeName x) Nothing Nothing [] [] DoNotChase
+#else
         mkDefault x = MacApp (exeName x) Nothing Nothing [] [] DoNotChase
+#endif
 
         -- Check if a MacApp is in that list of buildable executables.
         buildableApp :: MacApp -> Bool
-        buildableApp app = any (\e -> exeName e == appName app) buildables
+        buildableApp app = any (\e -> exeName e == fromString (appName app)) buildables
 
         -- List of buildable executables from .cabal file.
         buildables :: [Executable]

--- a/Distribution/MacOSX/Internal.hs
+++ b/Distribution/MacOSX/Internal.hs
@@ -43,7 +43,7 @@ getMacAppsForBuildableExecutors macApps executables =
     [] -> map mkDefault buildables
     xs -> filter buildableApp xs
   where -- Make a default MacApp in absence of explicit from Setup.hs
-#if MIN_VERSION_Cabal(2,0,0)
+#if MIN_VERSION_Cabal(1,25,0)
         mkDefault x = MacApp (display $ exeName x) Nothing Nothing [] [] DoNotChase
 #else
         mkDefault x = MacApp (exeName x) Nothing Nothing [] [] DoNotChase
@@ -51,7 +51,11 @@ getMacAppsForBuildableExecutors macApps executables =
 
         -- Check if a MacApp is in that list of buildable executables.
         buildableApp :: MacApp -> Bool
-        buildableApp app = any (\e -> exeName e == fromString (appName app)) buildables
+#if MIN_VERSION_Cabal(1,25,0)
+        buildableApp app = any (\e -> display (exeName e) == appName app) buildables
+#else
+        buildableApp app = any (\e -> exeName e == appName app) buildables
+#endif
 
         -- List of buildable executables from .cabal file.
         buildables :: [Executable]


### PR DESCRIPTION
This is needed for Cabal >=2.0. ~~Not sure what to do about <2.0 yet.~~

Tentative fix for #10