### PR TITLE
Obsidiansystems cabal 2

### DIFF
--- a/Distribution/MacOSX/Internal.hs
+++ b/Distribution/MacOSX/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 {- | Cabal support for creating Mac OSX application bundles.
 
 GUI applications on Mac OSX should be run as application /bundles/;
@@ -25,7 +26,9 @@ import System.Cmd ( system )
 import System.Exit
 import System.FilePath
 import Control.Monad (filterM)
+import Data.String (fromString)
 import System.Directory (doesDirectoryExist)
+import Distribution.Text (display)
 import Distribution.PackageDescription (BuildInfo(..), Executable(..))
 
 import Distribution.MacOSX.Common
@@ -40,11 +43,15 @@ getMacAppsForBuildableExecutors macApps executables =
     [] -> map mkDefault buildables
     xs -> filter buildableApp xs
   where -- Make a default MacApp in absence of explicit from Setup.hs
+#if MIN_VERSION_Cabal(2,0,0)
+        mkDefault x = MacApp (display $ exeName x) Nothing Nothing [] [] DoNotChase
+#else
         mkDefault x = MacApp (exeName x) Nothing Nothing [] [] DoNotChase
+#endif
 
         -- Check if a MacApp is in that list of buildable executables.
         buildableApp :: MacApp -> Bool
-        buildableApp app = any (\e -> exeName e == appName app) buildables
+        buildableApp app = any (\e -> exeName e == fromString (appName app)) buildables
 
         -- List of buildable executables from .cabal file.
         buildables :: [Executable]

--- a/Distribution/MacOSX/Internal.hs
+++ b/Distribution/MacOSX/Internal.hs
@@ -21,16 +21,18 @@ module Distribution.MacOSX.Internal (
   osxIncantations
 ) where
 
+#if MIN_VERSION_Cabal(2,0,0)
+import Data.String (fromString)
+import Distribution.Text (display)
+#endif
 import Prelude hiding ( catch )
 import System.Cmd ( system )
 import System.Exit
 import System.FilePath
 import Control.Monad (filterM)
-import Data.String (fromString)
 import System.Directory (doesDirectoryExist)
-import Distribution.Text (display)
-import Distribution.PackageDescription (BuildInfo(..), Executable(..))
 
+import Distribution.PackageDescription (BuildInfo(..), Executable(..))
 import Distribution.MacOSX.Common
 
 -- | Filter or create new 'MacApp's that are associated by name to buildable 'Executable's.
@@ -51,7 +53,11 @@ getMacAppsForBuildableExecutors macApps executables =
 
         -- Check if a MacApp is in that list of buildable executables.
         buildableApp :: MacApp -> Bool
+#if MIN_VERSION_Cabal(2,0,0)
         buildableApp app = any (\e -> exeName e == fromString (appName app)) buildables
+#else
+        buildableApp app = any (\e -> exeName e == appName app) buildables
+#endif
 
         -- List of buildable executables from .cabal file.
         buildables :: [Executable]


### PR DESCRIPTION
I have some doubts about this commit:

1) Why for the new Cabal do we need that change? I can see that something is wrong from the reported Issue based on Cabal-install version 2.1.0.0 but I don't understand why you applied this change.

2) Also that change for the cabal version should be reproduced from Travis, adding the new Cabal version along with (at least) one GHC version.

3) Tests in `Distribution/MacOSX/Internal/Tests.hs` should be changed to reflect the new changes. That probably would justify the change.